### PR TITLE
fix: update build.sh to match the package's name - NCD_playground (Cargo.toml)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,5 +2,5 @@
 set -e
 
 RUSTFLAGS='-C link-arg=-s' cargo build --target wasm32-unknown-unknown --release
-cp target/wasm32-unknown-unknown/release/ncd_playground.wasm ./res/
+cp target/wasm32-unknown-unknown/release/NCD_playground.wasm ./res/
 


### PR DESCRIPTION
./build.sh returns this error: `cp: cannot stat 'target/wasm32-unknown-unknown/release/ncd_playground.wasm': No such file or directory`. This is because the output is **NCD_playground.wasm**.

After updating ./build.sh works as expected.